### PR TITLE
fix: always escape keys in exported objects

### DIFF
--- a/migration/v1_to_v2/data/export_data.rb
+++ b/migration/v1_to_v2/data/export_data.rb
@@ -16,7 +16,7 @@ def exporters
 end
 
 exporters.each do |exporter|
-  data_exporter = Object.const_get(exporter).new(batch_size: 250)
+  data_exporter = Object.const_get(exporter).new
   data_exporter.export
 end
 

--- a/migration/v1_to_v2/data/exporters/attachment_exporter.rb
+++ b/migration/v1_to_v2/data/exporters/attachment_exporter.rb
@@ -18,7 +18,7 @@ class AttachmentExporter < DataExporter
     'other_documents' => 'other_documents'
   }.freeze
 
-  def initialize(options = {})
+  def initialize(options = { batch_size: 50 })
     super(options)
     @indent = 0
     @json_to_export = {}
@@ -197,7 +197,7 @@ class AttachmentExporter < DataExporter
      end
 
 
-     attachments.each_slice(100) do |slice|
+     attachments.each_slice(10) do |slice|
        slice.each do |form, file|
          render_attachment_importer(form, file)
        end

--- a/migration/v1_to_v2/data/exporters/attachment_exporter.rb
+++ b/migration/v1_to_v2/data/exporters/attachment_exporter.rb
@@ -182,7 +182,7 @@ class AttachmentExporter < DataExporter
     initialize_script_for_attachment(folder_to_save, type, sufix)
     files_to_write = data_object_names.
       reject { |type| @json_to_export[type].blank? }.
-      flat_map { |type| @json_to_export[type].values }.
+      flat_map { |type| @json_to_export[type].values.map(&:to_a) }.
       flat_map { |form, records| records.map { |record| [form, record] } }
     
     files_to_write.each_slice(100) do |form, data|

--- a/migration/v1_to_v2/data/exporters/data_exporter.rb
+++ b/migration/v1_to_v2/data/exporters/data_exporter.rb
@@ -143,14 +143,8 @@ class DataExporter
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 
-  def valid_key?(key)
-    return false if key.is_a?(Integer) || key.include?('-') || key.include?(' ') || !key.match?('^[a-zA-Z]')
-
-    true
-  end
-
   def key_to_ruby(key)
-    valid_key?(key) ? key : "'#{key}'"
+    "'#{ key.gsub(/'/, "\'") }'"
   end
 
   def parse_date_and_location_fields(object, data_hash)

--- a/migration/v1_to_v2/data/exporters/data_exporter.rb
+++ b/migration/v1_to_v2/data/exporters/data_exporter.rb
@@ -144,7 +144,7 @@ class DataExporter
   # rubocop:enable Metrics/AbcSize
 
   def key_to_ruby(key)
-    "'#{ key.gsub(/'/, "\'") }'"
+    "'#{ key.gsub(/'/, "\\'") }'"
   end
 
   def parse_date_and_location_fields(object, data_hash)

--- a/migration/v1_to_v2/data/exporters/data_exporter.rb
+++ b/migration/v1_to_v2/data/exporters/data_exporter.rb
@@ -144,7 +144,7 @@ class DataExporter
   # rubocop:enable Metrics/AbcSize
 
   def key_to_ruby(key)
-    "'#{ key.gsub(/'/, "\\'") }'"
+    "'#{ key.to_s.gsub(/'/, "\\'") }'"
   end
 
   def parse_date_and_location_fields(object, data_hash)


### PR DESCRIPTION
Previously we were erroneously testing to see if a value was a valid ruby key. This returned true even when the value was not a valid ruby key e.g. 

```
'A's Fake Name': {
```

```
Ghtc_Hyuik_1[1]_160x160: {
```
I've change this behavior so that all keys are wrapped in single quotes and, if any single quotes exist in the key string they are escaped e.g.

```
'A\'s Fake Name': {
```

```
'Ghtc_Hyuik_1[1]_160x160': {
```