### PR TITLE
Forcing a light GC every 100 attachements imported

### DIFF
--- a/migration/v1_to_v2/data/export_data.rb
+++ b/migration/v1_to_v2/data/export_data.rb
@@ -16,7 +16,7 @@ def exporters
 end
 
 exporters.each do |exporter|
-  data_exporter = Object.const_get(exporter).new(batch_size: 250)
+  data_exporter = Object.const_get(exporter).new
   data_exporter.export
 end
 

--- a/migration/v1_to_v2/data/exporters/attachment_exporter.rb
+++ b/migration/v1_to_v2/data/exporters/attachment_exporter.rb
@@ -18,7 +18,7 @@ class AttachmentExporter < DataExporter
     'other_documents' => 'other_documents'
   }.freeze
 
-  def initialize(options = {})
+  def initialize(options = { batch_size: 50 })
     super(options)
     @indent = 0
     @json_to_export = {}
@@ -197,7 +197,7 @@ class AttachmentExporter < DataExporter
      end
 
 
-     attachments.each_slice(100) do |slice|
+     attachments.each_slice(10) do |slice|
        slice.each do |form, file|
          render_attachment_importer(form, file)
        end

--- a/migration/v1_to_v2/data/exporters/attachment_exporter.rb
+++ b/migration/v1_to_v2/data/exporters/attachment_exporter.rb
@@ -182,7 +182,7 @@ class AttachmentExporter < DataExporter
     initialize_script_for_attachment(folder_to_save, type, sufix)
     files_to_write = data_object_names.
       reject { |type| @json_to_export[type].blank? }.
-      flat_map { |type| @json_to_export[type].values }.
+      flat_map { |type| @json_to_export[type].values.map(&:to_a) }.
       flat_map { |form, records| records.map { |record| [form, record] } }
     
     files_to_write.each_slice(100) do |form, data|


### PR DESCRIPTION
On some installations we can see upwards of 5GB of attachment data. When we try and load all of this into rails at once, depending on the available machine memory, we can see OOM exceptions which can bring everything down! Yay.

We're injecting a manual GC every 100 attachment loads which will drastically reduce the lifetime of the attachment objects.